### PR TITLE
recheck CoreOS use cases

### DIFF
--- a/content/org/openscore/slang/coreos/list_machines_public_ip.sl
+++ b/content/org/openscore/slang/coreos/list_machines_public_ip.sl
@@ -31,7 +31,7 @@ flow:
     - coreos_password:
         default: "''"
         overridable: false
-    - privateKeyFile:
+    - private_key_file:
         default: "''"
     - machines_public_ip_list:
         default: "''"


### PR DESCRIPTION
Fixes #64
updated an input name.. somebody changed private_key_file to privateKeyFile for a flow input, which I think is incorrect since we only use camelcase for Java action inputs - so I changed it back in order to make the flow work

Signed-off-by: Bonczidai Levente <levente.bonczidai@hp.com>