### PR TITLE
Moved linux flows from docker to base

### DIFF
--- a/content/org/openscore/slang/base/os/linux/check_linux_disk_space.sl
+++ b/content/org/openscore/slang/base/os/linux/check_linux_disk_space.sl
@@ -6,12 +6,12 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 ####################################################
-# Executes an empty SSH command.
+# Check the disk space percentage on a Linux machine.
 #
 # Inputs:
 #   - host - Docker machine host
 #   - port - optional - SSH port - Default: 22
-#   - username - Docker machine username
+#   - username  - Docker machine username
 #   - password - Docker machine password
 #   - privateKeyFile - optional - absolute path to private key file - Default: none
 #   - arguments - optional - arguments to pass to the command - Default: none
@@ -20,17 +20,16 @@
 #   - timeout - time in milliseconds to wait for command to complete - Default: 30000000
 #   - closeSession - optional - if false SSH session will be cached for future calls during the life of the flow, if true the SSH session used will be closed; Valid: true, false - Default: false
 # Outputs:
-#   - response - Linux welcome message
-#   - error_message
+#   - disk_space - percentage - Example: 50%
 # Results:
-#   - SUCCESS
-#   - FAILURE
+#   - SUCCESS - operation finished successfully
+#   - FAILURE - otherwise
 ####################################################
 
-namespace: org.openscore.slang.docker.linux
+namespace: org.openscore.slang.base.os.linux
 
 operation:
-  name: validate_linux_machine_ssh_access
+  name: check_linux_disk_space
   inputs:
     - host
     - port:
@@ -40,7 +39,8 @@ operation:
     - privateKeyFile:
         default: "''"
     - command:
-        default: "' '"
+        default: |
+            'df -kh | grep -v "Filesystem" | awk \'NR==1{print $5}\''
         overridable: false
     - arguments:
         default: "''"
@@ -57,8 +57,7 @@ operation:
       className: org.openscore.content.ssh.actions.SSHShellCommandAction
       methodName: runSshShellCommand
   outputs:
-    - response: STDOUT
-    - error_message: STDERR if returnCode == '0' else returnResult
+    - disk_space: STDOUT.replace("\n", "")
   results:
-    - SUCCESS : returnCode == '0' and (not 'Error' in STDERR)
+    - SUCCESS: returnCode == '0' and (not 'Error' in STDERR)
     - FAILURE

--- a/content/org/openscore/slang/base/os/linux/validate_linux_machine_ssh_access.sl
+++ b/content/org/openscore/slang/base/os/linux/validate_linux_machine_ssh_access.sl
@@ -6,12 +6,12 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 ####################################################
-# Check the disk space percentage on a Linux machine.
+# Executes an empty SSH command.
 #
 # Inputs:
 #   - host - Docker machine host
 #   - port - optional - SSH port - Default: 22
-#   - username  - Docker machine username
+#   - username - Docker machine username
 #   - password - Docker machine password
 #   - privateKeyFile - optional - absolute path to private key file - Default: none
 #   - arguments - optional - arguments to pass to the command - Default: none
@@ -20,16 +20,17 @@
 #   - timeout - time in milliseconds to wait for command to complete - Default: 30000000
 #   - closeSession - optional - if false SSH session will be cached for future calls during the life of the flow, if true the SSH session used will be closed; Valid: true, false - Default: false
 # Outputs:
-#   - disk_space - percentage - Example: 50%
+#   - response - Linux welcome message
+#   - error_message
 # Results:
-#   - SUCCESS - operation finished successfully
-#   - FAILURE - otherwise
+#   - SUCCESS
+#   - FAILURE
 ####################################################
 
-namespace: org.openscore.slang.docker.linux
+namespace: org.openscore.slang.base.os.linux
 
 operation:
-  name: check_linux_disk_space
+  name: validate_linux_machine_ssh_access
   inputs:
     - host
     - port:
@@ -39,8 +40,7 @@ operation:
     - privateKeyFile:
         default: "''"
     - command:
-        default: |
-            'df -kh | grep -v "Filesystem" | awk \'NR==1{print $5}\''
+        default: "' '"
         overridable: false
     - arguments:
         default: "''"
@@ -57,7 +57,8 @@ operation:
       className: org.openscore.content.ssh.actions.SSHShellCommandAction
       methodName: runSshShellCommand
   outputs:
-    - disk_space: STDOUT.replace("\n", "")
+    - response: STDOUT
+    - error_message: STDERR if returnCode == '0' else returnResult
   results:
-    - SUCCESS: returnCode == '0' and (not 'Error' in STDERR)
+    - SUCCESS : returnCode == '0' and (not 'Error' in STDERR)
     - FAILURE

--- a/content/org/openscore/slang/docker/images/clear_docker_dangling_images_flow.sl
+++ b/content/org/openscore/slang/docker/images/clear_docker_dangling_images_flow.sl
@@ -21,7 +21,7 @@ namespace: org.openscore.slang.docker.images
 
 imports:
  docker_images: org.openscore.slang.docker.images
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
  base_lists: org.openscore.slang.base.lists
 
 flow:
@@ -37,7 +37,7 @@ flow:
   workflow:
     - validate_linux_machine_ssh_access:
         do:
-          docker_linux.validate_linux_machine_ssh_access:
+          base_os_linux.validate_linux_machine_ssh_access:
             - host: docker_host
             - username: docker_username
             - password: docker_password

--- a/content/org/openscore/slang/docker/images/clear_docker_images_flow.sl
+++ b/content/org/openscore/slang/docker/images/clear_docker_images_flow.sl
@@ -21,7 +21,7 @@ namespace: org.openscore.slang.docker.images
 
 imports:
  docker_images: org.openscore.slang.docker.images
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
  base_lists: org.openscore.slang.base.lists
 
 flow:
@@ -36,7 +36,7 @@ flow:
   workflow:
     - validate_linux_machine_ssh_access:
         do:
-          docker_linux.validate_linux_machine_ssh_access:
+          base_os_linux.validate_linux_machine_ssh_access:
             - host: docker_host
             - username: docker_username
             - password: docker_password

--- a/content/org/openscore/slang/docker/images/clear_unused_docker_images.sl
+++ b/content/org/openscore/slang/docker/images/clear_unused_docker_images.sl
@@ -24,7 +24,7 @@ namespace: org.openscore.slang.docker.images
 
 imports:
  docker_images: org.openscore.slang.docker.images
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
 
 flow:
   name: clear_unused_docker_images

--- a/content/org/openscore/slang/docker/images/get_used_images_flow.sl
+++ b/content/org/openscore/slang/docker/images/get_used_images_flow.sl
@@ -20,7 +20,7 @@ namespace: org.openscore.slang.docker.images
 
 imports:
  docker_images: org.openscore.slang.docker.images
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
 
 flow:
   name: get_used_images_flow
@@ -34,7 +34,7 @@ flow:
   workflow:
     - validate_linux_machine_ssh_access_op:
         do:
-          docker_linux.validate_linux_machine_ssh_access:
+          base_os_linux.validate_linux_machine_ssh_access:
             - host: docker_host
             - username: docker_username
             - password: docker_password

--- a/content/org/openscore/slang/docker/maintenance/diskspace_health_check.sl
+++ b/content/org/openscore/slang/docker/maintenance/diskspace_health_check.sl
@@ -23,7 +23,7 @@
 namespace: org.openscore.slang.docker.maintenance
 
 imports:
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
  base_comparisons: org.openscore.slang.base.comparisons
 
 flow:
@@ -39,14 +39,14 @@ flow:
   workflow:
     - validate_linux_machine_ssh_access:
         do:
-          docker_linux.validate_linux_machine_ssh_access:
+          base_os_linux.validate_linux_machine_ssh_access:
             - host: docker_host
             - username: docker_username
             - password: docker_password
             - privateKeyFile: private_key_file
     - check_disk_space:
         do:
-          docker_linux.check_linux_disk_space:
+          base_os_linux.check_linux_disk_space:
             - host: docker_host
             - username: docker_username
             - password: docker_password

--- a/content/org/openscore/slang/docker/maintenance/docker_images_maintenance.sl
+++ b/content/org/openscore/slang/docker/maintenance/docker_images_maintenance.sl
@@ -22,7 +22,7 @@ namespace: org.openscore.slang.docker.maintenance
 
 imports:
  docker_maintenance: org.openscore.slang.docker.maintenance
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
  docker_images: org.openscore.slang.docker.images
 
 flow:

--- a/content/org/openscore/slang/docker/maintenance/retrieve_mysql_status.sl
+++ b/content/org/openscore/slang/docker/maintenance/retrieve_mysql_status.sl
@@ -32,7 +32,7 @@ namespace: org.openscore.slang.docker.maintenance
 
 imports:
  docker_maintenance: org.openscore.slang.docker.maintenance
- docker_linux: org.openscore.slang.docker.linux
+ base_os_linux: org.openscore.slang.base.os.linux
 
 flow:
   name: retrieve_mysql_status
@@ -50,7 +50,7 @@ flow:
   workflow:
     - validate_linux_machine_ssh_access:
             do:
-              docker_linux.validate_linux_machine_ssh_access:
+              base_os_linux.validate_linux_machine_ssh_access:
                 - host: docker_host
                 - username: docker_username
                 - password: docker_password


### PR DESCRIPTION
Moved validate_linux_machine_ssh_access.sl, check_linux_disk_space.sl from  content/org/openscore/slang/docker/linux to content/org/openscore/slang/base/os/linux. Also changed flows that use them

Signed-off-by: Lesan Tudor <tudor-andrei.lesan@hp.com>